### PR TITLE
Update authenticateToken.js

### DIFF
--- a/middleware/authenticateToken.js
+++ b/middleware/authenticateToken.js
@@ -50,8 +50,6 @@ const verifyRefreshToken = async (token) => {
 
 // Middleware to authenticate JWT
 const verifyAccessToken = async (token, prisma, userID) => {
-  const token = req.headers['authorization'] && req.headers['authorization'].split(' ')[1];
-
   if (!token) return res.sendStatus(401);
 
   const { isValid, decoded } = await verifyJWT(token, process.env.JWT_ACCESS_SECRET);


### PR DESCRIPTION
Fix - SyntaxError: Identifier 'token' has already been declared

Functionality of removed line is performed already in first line of authenticateToken()